### PR TITLE
Fixed build with latest tiktok sdk and latest react native version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('Tiktok_compileSdkVersion', 30)
+    compileSdkVersion safeExtGet('Tiktok_compileSdkVersion', 33)
     buildToolsVersion safeExtGet('Tiktok_buildToolsVersion', '30.0.2')
     defaultConfig {
-        minSdkVersion safeExtGet('Tiktok_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('Tiktok_targetSdkVersion', 30)
+        minSdkVersion safeExtGet('Tiktok_minSdkVersion', 21)
+        targetSdkVersion safeExtGet('Tiktok_targetSdkVersion', 33)
         versionCode 1
         versionName "1.0"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,5 +56,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation 'com.bytedance.ies.ugc.aweme:opensdk-oversea-external:0.2.0.2'
+    implementation 'com.bytedance.ies.ugc.aweme:opensdk-oversea-external:0.2.1.0'
 }

--- a/android/src/main/java/com/reactnativetiktok/TikTokEntryActivity.java
+++ b/android/src/main/java/com/reactnativetiktok/TikTokEntryActivity.java
@@ -5,13 +5,13 @@ import android.os.Bundle;
 import android.util.Log;
 import android.util.Pair;
 import android.widget.Toast;
-import com.bytedance.sdk.open.aweme.TikTokOpenApiFactory;
-import com.bytedance.sdk.open.aweme.api.TikTokApiEventHandler;
-import com.bytedance.sdk.open.aweme.api.TiktokOpenApi;
-import com.bytedance.sdk.open.aweme.authorize.model.Authorization;
-import com.bytedance.sdk.open.aweme.common.model.BaseReq;
-import com.bytedance.sdk.open.aweme.common.model.BaseResp;
-import com.bytedance.sdk.open.aweme.share.Share;
+import com.bytedance.sdk.open.tiktok.TikTokOpenApiFactory;
+import com.bytedance.sdk.open.tiktok.common.handler.IApiEventHandler;
+import com.bytedance.sdk.open.tiktok.api.TikTokOpenApi;
+import com.bytedance.sdk.open.tiktok.authorize.model.Authorization;
+import com.bytedance.sdk.open.tiktok.common.model.BaseReq;
+import com.bytedance.sdk.open.tiktok.common.model.BaseResp;
+import com.bytedance.sdk.open.tiktok.share.Share;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
@@ -20,14 +20,14 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import java.util.Properties;
 
-public class TikTokEntryActivity extends ReactActivity implements TikTokApiEventHandler {
-    TiktokOpenApi ttOpenApi;
+public class TikTokEntryActivity extends ReactActivity implements IApiEventHandler {
+    TikTokOpenApi ttOpenApi;
 
     public void onReq(BaseReq baseReq) {}
 
     public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
-        TiktokOpenApi create = TikTokOpenApiFactory.create(this);
+        TikTokOpenApi create = TikTokOpenApiFactory.create(this);
         this.ttOpenApi = create;
         create.handleIntent(getIntent(), this);
     }

--- a/android/src/main/java/com/reactnativetiktok/TiktokModule.java
+++ b/android/src/main/java/com/reactnativetiktok/TiktokModule.java
@@ -75,7 +75,7 @@ public class TiktokModule extends ReactContextBaseJavaModule {
     public void auth(Callback callBack) {
       TiktokOpenApi tiktokOpenApi = TikTokOpenApiFactory.create(getReactApplicationContext());
       Authorization.Request request = new Authorization.Request();
-      request.scope = "user.info.basic,video.list";
+      request.scope = "user.info.basic";
       request.callerLocalEntry = "com.reactnativetiktok.TikTokEntryActivity";
       tiktokOpenApi.authorize(request);
     }

--- a/android/src/main/java/com/reactnativetiktok/TiktokModule.java
+++ b/android/src/main/java/com/reactnativetiktok/TiktokModule.java
@@ -7,13 +7,13 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.core.content.FileProvider;
 
-import com.bytedance.sdk.open.aweme.TikTokOpenApiFactory;
-import com.bytedance.sdk.open.aweme.TikTokOpenConfig;
-import com.bytedance.sdk.open.aweme.api.TiktokOpenApi;
-import com.bytedance.sdk.open.aweme.authorize.model.Authorization;
-import com.bytedance.sdk.open.aweme.base.TikTokMediaContent;
-import com.bytedance.sdk.open.aweme.base.TikTokVideoObject;
-import com.bytedance.sdk.open.aweme.share.Share;
+import com.bytedance.sdk.open.tiktok.TikTokOpenApiFactory;
+import com.bytedance.sdk.open.tiktok.TikTokOpenConfig;
+import com.bytedance.sdk.open.tiktok.api.TikTokOpenApi;
+import com.bytedance.sdk.open.tiktok.authorize.model.Authorization;
+import com.bytedance.sdk.open.tiktok.base.MediaContent;
+import com.bytedance.sdk.open.tiktok.base.VideoObject;
+import com.bytedance.sdk.open.tiktok.share.Share;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -30,14 +30,14 @@ public class TiktokModule extends ReactContextBaseJavaModule {
     public static final String NAME = "Tiktok";
 
     private void Share(String path) {
-      TiktokOpenApi tiktokOpenApi = TikTokOpenApiFactory.create(getReactApplicationContext());
+      TikTokOpenApi tiktokOpenApi = TikTokOpenApiFactory.create(getCurrentActivity());
       Share.Request request = new Share.Request();
       request.callerLocalEntry = "com.reactnativetiktok.TikTokEntryActivity";
       ArrayList<String> mUri = new ArrayList<>();
       mUri.add(getFileUri(path));
-      TikTokVideoObject videoObject = new TikTokVideoObject();
+      VideoObject videoObject = new VideoObject();
       videoObject.mVideoPaths = mUri;
-      TikTokMediaContent content = new TikTokMediaContent();
+      MediaContent content = new MediaContent();
       content.mMediaObject = videoObject;
       request.mMediaContent = content;
       tiktokOpenApi.share(request);
@@ -73,7 +73,7 @@ public class TiktokModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void auth(Callback callBack) {
-      TiktokOpenApi tiktokOpenApi = TikTokOpenApiFactory.create(getReactApplicationContext());
+      TikTokOpenApi tiktokOpenApi = TikTokOpenApiFactory.create(getCurrentActivity());
       Authorization.Request request = new Authorization.Request();
       request.scope = "user.info.basic";
       request.callerLocalEntry = "com.reactnativetiktok.TikTokEntryActivity";


### PR DESCRIPTION
Hi.
We tried using this plugin and we encountered a few issues:
- `error: resource android:attr/lStar not found`
- `TikTokOpenApiFactory symbol not found`

This PR fixes the issues we found, however we did not test the share functionality yet.
- changed target sdk version to: 33, and min sdk to 21 - this fixed the first error
- update `com.bytedance.ies.ugc.aweme:opensdk-oversea-external` to `v0.2.1.0`
- Modified TiktokModule.java and TikTokEntryActivity.java to be compatible with the new sdk version

We tested this on a react-native v0.70.3 project.
Also, the list of scopes should be configurable from the js auth function in a future update.