### PR TITLE
fix: correct parameter order in authorize method

### DIFF
--- a/ios/Tiktok.mm
+++ b/ios/Tiktok.mm
@@ -5,8 +5,8 @@
 
 RCT_EXTERN_METHOD(
                   authorize: (NSString)redirectURI
-                  callback: (RCTResponseSenderBlock)callback
                   scopes:(NSArray * _Nullable)scopes
+                  callback: (RCTResponseSenderBlock)callback
                   )
 
 + (BOOL)requiresMainQueueSetup

--- a/ios/Tiktok.swift
+++ b/ios/Tiktok.swift
@@ -6,7 +6,7 @@ class Tiktok: RCTEventEmitter {
   let authRequest = TikTokAuthRequest(scopes: [], redirectURI: "")
 
   @objc
-  func authorize(_ redirectURI: String, callback: @escaping RCTResponseSenderBlock, scopes: [String]?) -> Void {
+  func authorize(_ redirectURI: String, scopes: [String]?, callback: @escaping RCTResponseSenderBlock) -> Void {
     DispatchQueue.main.async {
       self.authRequest.redirectURI = redirectURI
       self.authRequest.scopes = Set(scopes ?? ["user.info.basic"])

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,5 +29,5 @@ const Tiktok = NativeModules.Tiktok;
 
 export function authorize(props: Props): void {
   const { redirectURI, callback, scopes } = props;
-  return Tiktok.authorize(redirectURI, callback, scopes);
+  return Tiktok.authorize(redirectURI, scopes, callback);
 }


### PR DESCRIPTION
- Fix parameter order mismatch between Swift implementation and JS interface
- Move scopes parameter before callback to maintain consistency across platforms
- Prevents potential runtime crashes due to type mismatches
- Follows React Native bridging best practices

Changes:
- ios/Tiktok.mm: Updated RCT_EXTERN_METHOD parameter order
- ios/Tiktok.swift: Updated authorize method signature
- src/index.tsx: Updated authorize function call